### PR TITLE
Export utils module

### DIFF
--- a/src/lend/v2/index.ts
+++ b/src/lend/v2/index.ts
@@ -10,3 +10,4 @@ export * from "./mathLib";
 export * from "./opup";
 export * from "./oracle";
 export * from "./types";
+export * from "./utils";


### PR DESCRIPTION
Exports utils module 

So I can do this

`import { getEscrows } from 'folks-finance-js-sdk'`

instead of this

`import { getEscrows } from 'folks-finance-js-sdk/dist/lend/v2/utils.js'`