### PR TITLE
Fixed totalBorrowedAmountValue sum in userLoanInfo

### DIFF
--- a/src/lend/v2/utils.ts
+++ b/src/lend/v2/utils.ts
@@ -449,7 +449,7 @@ export function userLoanInfo(
         ? compoundEverySecond(stableBorrowInterestRate, ONE_16_DP)
         : poolInfo.variableBorrowInterestYield;
 
-      totalBorrowedAmountValue += borrowedAmount;
+      totalBorrowedAmountValue += borrowedAmountValue;
       totalBorrowBalanceValue += borrowBalanceValue;
       totalEffectiveBorrowBalanceValue += effectiveBorrowBalanceValue;
       netRate -= borrowBalanceValue * interestRate;


### PR DESCRIPTION
Courtesy of @AlgoPixels ([original PR](https://github.com/algolog/ff-py-sdk/pull/1)):
> Previously the sum was not summing the dollarized amounts, screwing things a bit.
Noticed this because totalBorrowedAmountValue had not 4 d.p. during tests